### PR TITLE
squash! cmake: Check for availability of softfp libararies

### DIFF
--- a/common.cmake
+++ b/common.cmake
@@ -41,6 +41,18 @@ function(nrfxlib_calculate_lib_path lib_path)
   set(${lib_path} "lib/${arch_soc_dir}/${float_dir}${short_wchar}" PARENT_SCOPE)
 endfunction()
 
+function(nrfxlib_check_softfp_path lib_name)
+  if (CONFIG_FP_SOFTABI)
+    set(lib_full_path ${${lib_name}})
+    string(REGEX REPLACE "softfp-float" "soft-float" soft_path ${lib_full_path})
+
+    if(NOT EXISTS ${lib_full_path} AND EXISTS ${soft_path})
+      message("There is no softfp version for library ${lib_name}, using the soft-float version.")
+      set(${lib_name} ${soft_path} PARENT_SCOPE)
+    endif()
+  endif()
+endfunction()
+
 function(get_mbedtls_dir ARM_MBEDTLS_PATH_ARG)
   if(EXISTS ${${ARM_MBEDTLS_PATH_ARG}})
   # Do nothing, just use the provided path

--- a/common.cmake
+++ b/common.cmake
@@ -4,15 +4,35 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
+# Usage:
+#   nrfxlib_calculate_lib_path(<dir> [SOC_MODE] [BASE_DIR <dir> [SOFT_FLOAT_FALLBACK]])
 #
-# Build the path of the library taking in
-# -Arch type
-# -Float ABI
-# -wchar_t size
+# Calculate a library path based on current SoC architecture or SoC name and
+# FPU ABI mode.
+# The calculated library path is returned in the '<dir>' argument.
 #
+# If BASE_DIR is specified the calculated path will be converted to an absolute
+# path starting from BASE_DIR. The absolute path will be checked for existence
+# and if the absolute path does not exists, the returned value will be
+# '<dir>-NOTFOUND'.
+#
+# SOC_MODE:            Use the SoC name instead of the SoC architecture when calculating the path.
+#                      For example 'nrf52840' will be used for the path instead of 'cortex-m4'
+# BASE_DIR:            Base path from where the calculated path should start from.
+#                      When specifying BASE_DIR the path returned will be absolute, or
+#                      '<dir>-NOTFOUND' if the path does not exists
+# SOFT_FLOAT_FALLBACK: Allow soft float library path fallback if softfp-float is the FPU ABI in use
+#                      and no 'softfp-float' is found.
+#                      This flag requires 'BASE_DIR'
+# 
 function(nrfxlib_calculate_lib_path lib_path)
-  cmake_parse_arguments(CALC_LIB_PATH "SOC_MODE" "" "" ${ARGN})
+  cmake_parse_arguments(CALC_LIB_PATH "SOFT_FLOAT_FALLBACK;SOC_MODE" "BASE_DIR" "" ${ARGN})
 
+  if(CALC_LIB_PATH_SOFT_FLOAT_FALLBACK AND NOT DEFINED CALC_LIB_PATH_BASE_DIR)
+    message(WARNING "nrfxlib_calculate_lib_path(SOFT_FLOAT_FALLBACK ...) "
+      "depends on argument: BASE_DIR."
+    )
+  endif()
   if(${CALC_LIB_PATH_SOC_MODE})
     # CMake regex does not support {4}
     string(REGEX REPLACE "_[a-zA-Z][a-zA-Z][a-zA-Z][a-zA-Z]$" "" arch_soc_dir ${CONFIG_SOC})
@@ -25,31 +45,34 @@ function(nrfxlib_calculate_lib_path lib_path)
   # Set floating ABI
   if(CONFIG_FPU)
     if(CONFIG_FP_HARDABI)
-        set(float_dir hard-float)
+      set(float_dir hard-float)
     elseif(CONFIG_FP_SOFTABI)
-        set(float_dir softfp-float)
+      set(float_dir softfp-float)
+      if(CALC_LIB_PATH_SOFT_FLOAT_FALLBACK AND DEFINED CALC_LIB_PATH_BASE_DIR)
+        list(APPEND float_dir soft-float)
+      endif()
     else()
-        assert(0 "Unreachable code")
+      assert(0 "Unreachable code")
     endif()
   else()
-	  set(float_dir soft-float)
+    set(float_dir soft-float)
   endif()
   list(FIND COMPILER_OPT_AS_LIST "-fshort-wchar" SHORT_WCHAR_INDEX)
   if (NOT (SHORT_WCHAR_INDEX EQUAL -1))
     set(short_wchar "/short-wchar")
   endif()
-  set(${lib_path} "lib/${arch_soc_dir}/${float_dir}${short_wchar}" PARENT_SCOPE)
-endfunction()
 
-function(nrfxlib_check_softfp_path lib_name)
-  if (CONFIG_FP_SOFTABI)
-    set(lib_full_path ${${lib_name}})
-    string(REGEX REPLACE "softfp-float" "soft-float" soft_path ${lib_full_path})
-
-    if(NOT EXISTS ${lib_full_path} AND EXISTS ${soft_path})
-      message("There is no softfp version for library ${lib_name}, using the soft-float version.")
-      set(${lib_name} ${soft_path} PARENT_SCOPE)
-    endif()
+  if(DEFINED CALC_LIB_PATH_BASE_DIR)
+    foreach(dir ${float_dir})
+      set(${lib_path} "${CALC_LIB_PATH_BASE_DIR}/lib/${arch_soc_dir}/${dir}${short_wchar}")
+      if(EXISTS ${${lib_path}})
+        set(${lib_path} ${${lib_path}} PARENT_SCOPE)
+        return()
+      endif()
+    endforeach()
+    set(${lib_path} ${lib_path}-NOTFOUND PARENT_SCOPE)
+  else()
+    set(${lib_path} "lib/${arch_soc_dir}/${float_dir}${short_wchar}" PARENT_SCOPE)
   endif()
 endfunction()
 

--- a/crypto/CMakeLists.txt
+++ b/crypto/CMakeLists.txt
@@ -16,10 +16,10 @@ if (CONFIG_NRF_OBERON OR CONFIG_BUILD_WITH_TFM)
   set(OBERON_VER 3.0.8)
 
   set(OBERON_LIB ${OBERON_BASE}/${lib_path}/liboberon_${OBERON_VER}.a)
-  nrfxlib_check_softfp_path(OBERON_LIB)
+#  nrfxlib_check_softfp_path(OBERON_LIB)
 
   set(OBERON_MBEDTLS_LIB ${OBERON_BASE}/${lib_path}/liboberon_mbedtls_${OBERON_VER}.a)
-  nrfxlib_check_softfp_path(OBERON_MBEDTLS_LIB)
+#  nrfxlib_check_softfp_path(OBERON_MBEDTLS_LIB)
 
   if(NOT EXISTS ${OBERON_LIB})
     message(WARNING "This combination of SoC and floating point ABI is not supported by the nrf_oberon lib."
@@ -74,7 +74,7 @@ if (CONFIG_NRF_CC310_BL)
   endif()
   set(CC310_BL_VER 0.9.12)
   set(CC310_BL_LIB ${CC310_BL_BASE}/${lib_path}/${CC310_FLAVOR}/libnrf_cc310_bl_${CC310_BL_VER}.a)
-  nrfxlib_check_softfp_path(CC310_BL_LIB)
+#  nrfxlib_check_softfp_path(CC310_BL_LIB)
 
   if(NOT EXISTS ${CC310_BL_LIB})
     message(WARNING "This combination of SoC, floating point ABI, and interrupts settings is not supported by the nrf_cc310_bl lib."
@@ -95,10 +95,15 @@ if (CONFIG_NRF_CC3XX_PLATFORM)
   if (NOT CONFIG_HW_CC3XX_INTERRUPT)
     set(CC3XX_PLATFORM_FLAVOR no-interrupts)
   endif()
-  set(NRF_CC3XX_PLATFORM_LIB
-    ${NRF_CC3XX_PLATFORM_BASE}/${lib_path}/${CC3XX_PLATFORM_FLAVOR}/libnrf_${CC3XX_ARCH}_platform_${NRF_CC3XX_PLATFORM_VER}.a
+
+  nrfxlib_calculate_lib_path(NRF_CC3XX_PLATFORM_LIB_DIR
+    BASE_DIR ${NRF_CC3XX_PLATFORM_BASE}
+    SOFT_FLOAT_FALLBACK
   )
-  nrfxlib_check_softfp_path(NRF_CC3XX_PLATFORM_LIB)
+
+  set(NRF_CC3XX_PLATFORM_LIB
+    ${NRF_CC3XX_PLATFORM_LIB_DIR}/${CC3XX_PLATFORM_FLAVOR}/libnrf_${CC3XX_ARCH}_platform_${NRF_CC3XX_PLATFORM_VER}.a
+  )
 
   if (NOT EXISTS ${NRF_CC3XX_PLATFORM_LIB})
     message(WARNING "This combination of SoC, floating point ABI, and interrupts settings is not supported by the nrf_${CC3XX_ARCH}_platform lib."
@@ -141,7 +146,7 @@ if (CONFIG_CC3XX_BACKEND)
   set(NRF_CC3XX_LIB
     ${NRF_CC3XX_BASE}/${lib_path}/${CC3XX_FLAVOR}/libnrf_${CC3XX_ARCH}_mbedcrypto_${NRF_CC3XX_VER}.a
   )
-  nrfxlib_check_softfp_path(NRF_CC3XX_LIB)
+#  nrfxlib_check_softfp_path(NRF_CC3XX_LIB)
 
   if(NOT EXISTS ${NRF_CC3XX_LIB})
     message(WARNING "This combination of SoC, floating point ABI, and interrupts settings is not supported by the nrf_${CC3XX_ARCH}_mbedcryto lib."

--- a/crypto/CMakeLists.txt
+++ b/crypto/CMakeLists.txt
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2018 Nordic Semiconductor
+# Copyright (c) 2021 Nordic Semiconductor
 #
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
@@ -12,15 +12,15 @@ add_library(nrfxlib_crypto INTERFACE)
 
 if (CONFIG_NRF_OBERON OR CONFIG_BUILD_WITH_TFM)
 
-  # The oberon library doesn't have a softfp version so we replace its path with the soft-float one
-  if (CONFIG_FP_SOFTABI)
-        string(REGEX REPLACE "softfp-float" "soft-float"  lib_path ${lib_path})
-  endif()
-
   set(OBERON_BASE ${CMAKE_CURRENT_SOURCE_DIR}/nrf_oberon)
   set(OBERON_VER 3.0.8)
+
   set(OBERON_LIB ${OBERON_BASE}/${lib_path}/liboberon_${OBERON_VER}.a)
+  nrfxlib_check_softfp_path(OBERON_LIB)
+
   set(OBERON_MBEDTLS_LIB ${OBERON_BASE}/${lib_path}/liboberon_mbedtls_${OBERON_VER}.a)
+  nrfxlib_check_softfp_path(OBERON_MBEDTLS_LIB)
+
   if(NOT EXISTS ${OBERON_LIB})
     message(WARNING "This combination of SoC and floating point ABI is not supported by the nrf_oberon lib."
                     "(${OBERON_LIB} doesn't exist.)")
@@ -74,6 +74,8 @@ if (CONFIG_NRF_CC310_BL)
   endif()
   set(CC310_BL_VER 0.9.12)
   set(CC310_BL_LIB ${CC310_BL_BASE}/${lib_path}/${CC310_FLAVOR}/libnrf_cc310_bl_${CC310_BL_VER}.a)
+  nrfxlib_check_softfp_path(CC310_BL_LIB)
+
   if(NOT EXISTS ${CC310_BL_LIB})
     message(WARNING "This combination of SoC, floating point ABI, and interrupts settings is not supported by the nrf_cc310_bl lib."
                     "(${CC310_BL_LIB} doesn't exist.)")
@@ -96,6 +98,7 @@ if (CONFIG_NRF_CC3XX_PLATFORM)
   set(NRF_CC3XX_PLATFORM_LIB
     ${NRF_CC3XX_PLATFORM_BASE}/${lib_path}/${CC3XX_PLATFORM_FLAVOR}/libnrf_${CC3XX_ARCH}_platform_${NRF_CC3XX_PLATFORM_VER}.a
   )
+  nrfxlib_check_softfp_path(NRF_CC3XX_PLATFORM_LIB)
 
   if (NOT EXISTS ${NRF_CC3XX_PLATFORM_LIB})
     message(WARNING "This combination of SoC, floating point ABI, and interrupts settings is not supported by the nrf_${CC3XX_ARCH}_platform lib."
@@ -138,6 +141,8 @@ if (CONFIG_CC3XX_BACKEND)
   set(NRF_CC3XX_LIB
     ${NRF_CC3XX_BASE}/${lib_path}/${CC3XX_FLAVOR}/libnrf_${CC3XX_ARCH}_mbedcrypto_${NRF_CC3XX_VER}.a
   )
+  nrfxlib_check_softfp_path(NRF_CC3XX_LIB)
+
   if(NOT EXISTS ${NRF_CC3XX_LIB})
     message(WARNING "This combination of SoC, floating point ABI, and interrupts settings is not supported by the nrf_${CC3XX_ARCH}_mbedcryto lib."
                     "(${NRF_CC3XX_LIB} doesn't exist.)")

--- a/mpsl/CMakeLists.txt
+++ b/mpsl/CMakeLists.txt
@@ -4,14 +4,13 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
-nrfxlib_calculate_lib_path(lib_path)
+nrfxlib_calculate_lib_path(MPSL_LIB_PATH
+  BASE_DIR ${CMAKE_CURRENT_SOURCE_DIR}
+  SOFT_FLOAT_FALLBACK
+)
 
-set(MPSL_LIB_PATH ${CMAKE_CURRENT_SOURCE_DIR}/${lib_path})
-nrfxlib_check_softfp_path(MPSL_LIB_PATH)
-
-if(NOT EXISTS ${MPSL_LIB_PATH})
-  message(WARNING "This combination of SoC and floating point ABI is not supported by the MPSL lib."
-                  "(${MPSL_LIB_PATH} doesn't exist.)")
+if(NOT MPSL_LIB_PATH)
+  message(WARNING "This combination of SoC and floating point ABI is not supported by the MPSL lib.")
 endif()
 
 zephyr_include_directories(include)

--- a/mpsl/CMakeLists.txt
+++ b/mpsl/CMakeLists.txt
@@ -7,6 +7,7 @@
 nrfxlib_calculate_lib_path(lib_path)
 
 set(MPSL_LIB_PATH ${CMAKE_CURRENT_SOURCE_DIR}/${lib_path})
+nrfxlib_check_softfp_path(MPSL_LIB_PATH)
 
 if(NOT EXISTS ${MPSL_LIB_PATH})
   message(WARNING "This combination of SoC and floating point ABI is not supported by the MPSL lib."

--- a/nfc/CMakeLists.txt
+++ b/nfc/CMakeLists.txt
@@ -7,6 +7,7 @@
 nrfxlib_calculate_lib_path(lib_path)
 
 set(NFC_LIB_PATH ${CMAKE_CURRENT_SOURCE_DIR}/${lib_path})
+nrfxlib_check_softfp_path(NFC_LIB_PATH)
 
 if(NOT EXISTS ${NFC_LIB_PATH})
   message(WARNING "This combination of SoC and floating point ABI is not supported by the nfc lib."

--- a/nrf_802154/sl/sl/CMakeLists.txt
+++ b/nrf_802154/sl/sl/CMakeLists.txt
@@ -9,6 +9,7 @@ add_library(nrf-802154-sl INTERFACE)
 nrfxlib_calculate_lib_path(lib_path SOC_MODE)
 
 set(NRF_802154_SL_LIB_PATH ${CMAKE_CURRENT_SOURCE_DIR}/${lib_path})
+nrfxlib_check_softfp_path(NRF_802154_SL_LIB_PATH)
 
 if(NOT EXISTS ${NRF_802154_SL_LIB_PATH})
   message(WARNING "This combination of SoC and floating point ABI is not supported by the nrf_802154_sl lib."

--- a/nrf_modem/CMakeLists.txt
+++ b/nrf_modem/CMakeLists.txt
@@ -9,6 +9,7 @@ if(CONFIG_NRF_MODEM_LINK_BINARY)
   nrfxlib_calculate_lib_path(lib_path)
 
   set(NRF_MODEM_PATH ${CMAKE_CURRENT_SOURCE_DIR}/${lib_path})
+  nrfxlib_check_softfp_path(NRF_MODEM_PATH)
 
   if(NOT EXISTS ${NRF_MODEM_PATH})
      message(ERROR " This combination of SoC and floating point ABI is not supported by libmodem"

--- a/softdevice_controller/CMakeLists.txt
+++ b/softdevice_controller/CMakeLists.txt
@@ -10,14 +10,14 @@ if(CONFIG_BT_LL_SOFTDEVICE OR
 endif()
 
 if(CONFIG_BT_LL_SOFTDEVICE)
-  nrfxlib_calculate_lib_path(lib_path)
+  nrfxlib_calculate_lib_path(SOFTDEVICE_CONTROLLER_LIB_PATH
+    BASE_DIR ${CMAKE_CURRENT_SOURCE_DIR}
+    SOFT_FLOAT_FALLBACK
+  )
 
-  set(SOFTDEVICE_CONTROLLER_LIB_PATH ${CMAKE_CURRENT_SOURCE_DIR}/${lib_path})
-  nrfxlib_check_softfp_path(SOFTDEVICE_CONTROLLER_LIB_PATH)
-
-  if(NOT EXISTS ${SOFTDEVICE_CONTROLLER_LIB_PATH})
-    message(WARNING "This combination of SoC and floating point ABI is not supported by the SoftDevice Controller lib."
-      "(${SOFTDEVICE_CONTROLLER_LIB_PATH} doesn't exist.)")
+  if(NOT SOFTDEVICE_CONTROLLER_LIB_PATH)
+    message(WARNING "This combination of SoC and floating point ABI is not"
+      "supported by the SoftDevice Controller lib.")
   endif()
 
   if(CONFIG_SOFTDEVICE_CONTROLLER_PERIPHERAL)

--- a/softdevice_controller/CMakeLists.txt
+++ b/softdevice_controller/CMakeLists.txt
@@ -13,6 +13,7 @@ if(CONFIG_BT_LL_SOFTDEVICE)
   nrfxlib_calculate_lib_path(lib_path)
 
   set(SOFTDEVICE_CONTROLLER_LIB_PATH ${CMAKE_CURRENT_SOURCE_DIR}/${lib_path})
+  nrfxlib_check_softfp_path(SOFTDEVICE_CONTROLLER_LIB_PATH)
 
   if(NOT EXISTS ${SOFTDEVICE_CONTROLLER_LIB_PATH})
     message(WARNING "This combination of SoC and floating point ABI is not supported by the SoftDevice Controller lib."


### PR DESCRIPTION
Squash this into existing commit and continue the cleanup.

Feel free to adjust existing commit message with following text:

This commit extends existing `nrfxlib_calculate_lib_path()` function
to take a BASE_DIR.

The BASE_DIR allows the caller to specify a BASE_DIR from where the
lib path should be looked up.
When using a BASE_DIR the lib_path will be checked for existence before
the function returns. If the combined base directory and calculated
library path does not exists, the return variable `lib_path` will be set
to `${lib_path}-NOTFOUND` which means that the caller can use a simple
`if(<lib_path>)` construct to check the existence of the library path.

As addition, an optional `SOFT_FLOAT_FALLBACK` flag has been implemented
which allows a caller to request that a `soft-float` library path is
checked for existence if `softfp` ABI is selected but no `softfp`
library path was found.

Signed-off-by: Torsten Rasmussen <Torsten.Rasmussen@nordicsemi.no>